### PR TITLE
バイトコードの準拠バージョンをJava6にする

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.integration'
-version = '1.0.1'
+version = '1.0.2'
 description = 'JAX-RS実装のアダプタ'
 
 buildscript {
@@ -37,13 +37,13 @@ subprojects {
   apply from: "../cobertura-0.0.1.gradle"
 
   // ビルド時のJavaバージョンを指定する
-  sourceCompatibility=JavaVersion.VERSION_1_7
-  targetCompatibility=JavaVersion.VERSION_1_7
+  sourceCompatibility=JavaVersion.VERSION_1_6
+  targetCompatibility=JavaVersion.VERSION_1_6
 
   dependencies {
     provided 'javax:javaee-api:7.0'
 
-    compile 'com.nablarch.framework:nablarch-fw-jaxrs:1.0.1'
+    compile 'com.nablarch.framework:nablarch-fw-jaxrs:1.0.2'
     provided 'org.slf4j:slf4j-simple:1.7.10'
 
     testCompile 'org.jmockit:jmockit:1.19'

--- a/nablarch-jackson-adaptor/build.gradle
+++ b/nablarch-jackson-adaptor/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.integration'
-version = '1.0.1'
+version = '1.0.2'
 description = 'Jackson用アダプタ'
 
 jar.baseName='nablarch-jackson-adaptor'

--- a/nablarch-jackson-adaptor/pom.xml
+++ b/nablarch-jackson-adaptor/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.nablarch.integration</groupId>
   <artifactId>nablarch-jackson-adaptor</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <dependencies>
     <dependency>
       <groupId>com.nablarch.dev</groupId>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-fw-jaxrs</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/nablarch-jersey-adaptor/build.gradle
+++ b/nablarch-jersey-adaptor/build.gradle
@@ -1,11 +1,11 @@
 group = 'com.nablarch.integration'
-version = '1.0.1'
+version = '1.0.2'
 description = 'JAX-RS実装のJersey用アダプタ'
 
 jar.baseName='nablarch-jersey-adaptor'
 
 dependencies {
-  compile 'com.nablarch.integration:nablarch-jackson-adaptor:1.0.1'
+  compile 'com.nablarch.integration:nablarch-jackson-adaptor:1.0.2'
   testRuntime 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
 }
 

--- a/nablarch-jersey-adaptor/pom.xml
+++ b/nablarch-jersey-adaptor/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.nablarch.integration</groupId>
   <artifactId>nablarch-jersey-adaptor</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-fw-jaxrs</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.nablarch.integration</groupId>
       <artifactId>nablarch-jackson-adaptor</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/nablarch-resteasy-adaptor/build.gradle
+++ b/nablarch-resteasy-adaptor/build.gradle
@@ -1,10 +1,10 @@
 group = 'com.nablarch.integration'
-version = '1.0.1'
+version = '1.0.2'
 description = 'JAX-RS実装のRESTEasy用アダプタ'
 
 jar.baseName='nablarch-resteasy-adaptor'
 
 dependencies {
-  compile 'com.nablarch.integration:nablarch-jackson-adaptor:1.0.1'
+  compile 'com.nablarch.integration:nablarch-jackson-adaptor:1.0.2'
   testRuntime 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
 }

--- a/nablarch-resteasy-adaptor/pom.xml
+++ b/nablarch-resteasy-adaptor/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.nablarch.integration</groupId>
   <artifactId>nablarch-resteasy-adaptor</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-fw-jaxrs</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.nablarch.integration</groupId>
       <artifactId>nablarch-jackson-adaptor</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
#1
