### PR TITLE
公開APIを追加

### DIFF
--- a/nablarch-jackson-adaptor/src/main/java/nablarch/integration/jaxrs/jackson/Jackson2BodyConverter.java
+++ b/nablarch-jackson-adaptor/src/main/java/nablarch/integration/jaxrs/jackson/Jackson2BodyConverter.java
@@ -5,6 +5,7 @@ import java.io.Reader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import nablarch.core.util.annotation.Published;
 import nablarch.fw.jaxrs.BodyConverter;
 
 /**
@@ -12,6 +13,7 @@ import nablarch.fw.jaxrs.BodyConverter;
  *
  * @author Kiyohito Itoh
  */
+@Published(tag = "architect")
 public class Jackson2BodyConverter extends JacksonBodyConverterSupport {
 
     /** {@link ObjectMapper} */

--- a/nablarch-jackson-adaptor/src/main/java/nablarch/integration/jaxrs/jackson/JacksonBodyConverterSupport.java
+++ b/nablarch-jackson-adaptor/src/main/java/nablarch/integration/jaxrs/jackson/JacksonBodyConverterSupport.java
@@ -17,7 +17,7 @@ import java.io.Reader;
 
 /**
  * Jackson用の{@link nablarch.fw.jaxrs.BodyConverter}の実装をサポートするクラス。
- *
+ * <p>
  * このConverterは、メディアタイプが{@code application/json}で始まっている場合に
  * リクエスト/レスポンスを変換する。(大文字、小文字は問わない)
  *

--- a/nablarch-jackson-adaptor/src/main/java/nablarch/integration/jaxrs/jackson/JacksonBodyConverterSupport.java
+++ b/nablarch-jackson-adaptor/src/main/java/nablarch/integration/jaxrs/jackson/JacksonBodyConverterSupport.java
@@ -2,6 +2,7 @@ package nablarch.integration.jaxrs.jackson;
 
 import nablarch.core.log.Logger;
 import nablarch.core.log.LoggerManager;
+import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.jaxrs.BodyConverterSupport;
 import nablarch.fw.jaxrs.JaxRsContext;
@@ -22,6 +23,7 @@ import java.io.Reader;
  *
  * @author Kiyohito Itoh
  */
+@Published(tag = "architect")
 public abstract class JacksonBodyConverterSupport extends BodyConverterSupport {
 
     /** ロガー */


### PR DESCRIPTION
`Jackson2BodyConverter`については利用者側で少しカスタマイズして使用したいケースが多そうであることから、アーキテクト向けの公開APIとしました。
またこれを独自に拡張したい場合は`JacksonBodyConverterSupport`を親クラスとして使いたくなると想定し、こちらもアーキテクト向けの公開APIとしました。