### PR TITLE
Date and Time APIのサポートを追加

### DIFF
--- a/nablarch-jackson-adaptor/pom.xml
+++ b/nablarch-jackson-adaptor/pom.xml
@@ -15,7 +15,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.1</version>
     </dependency>
 
     <dependency>
@@ -29,11 +28,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.nablarch.dev</groupId>
       <artifactId>nablarch-test-support</artifactId>

--- a/nablarch-jersey-adaptor/pom.xml
+++ b/nablarch-jersey-adaptor/pom.xml
@@ -16,10 +16,8 @@
       <artifactId>nablarch-jackson-adaptor</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.17.1</version>
-      <scope>test</scope>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
 
     <dependency>
@@ -34,15 +32,24 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.nablarch.dev</groupId>
       <artifactId>nablarch-test-support</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <!-- 日付のシリアライズ結果に影響するため、タイムゾーンを固定 -->
+            <user.timezone>Asia/Tokyo</user.timezone>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/nablarch-jersey-adaptor/pom.xml
+++ b/nablarch-jersey-adaptor/pom.xml
@@ -37,19 +37,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <!-- 日付のシリアライズ結果に影響するため、タイムゾーンを固定 -->
-            <user.timezone>Asia/Tokyo</user.timezone>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
@@ -22,7 +22,7 @@ public class JerseyJackson2BodyConverter extends Jackson2BodyConverter {
     @Override
     protected void configure(ObjectMapper objectMapper) {
         objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));  // JacksonのデフォルトはUTC固定のため
+        objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
@@ -1,6 +1,5 @@
 package nablarch.integration.jaxrs.jersey;
 
-import java.time.ZoneId;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
@@ -10,18 +10,31 @@ import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
 /**
  * {@link JerseyJaxRsHandlerListFactory}向けの拡張実装として、Jackson2.xを使用してリクエスト/レスポンスの
  * 変換を行う{@link Jackson2BodyConverter}実装クラス。
- *
+ * <p>
  * Jackson2.xのモジュールを組み込み、{@link ObjectMapper}のサポートするデータ型の範囲を
  * 拡張する
  */
 public class JerseyJackson2BodyConverter extends Jackson2BodyConverter {
+    private ObjectMapper objectMapper;
+
     /**
      * {@inheritDoc}
      */
     @Override
-    protected void configure(ObjectMapper objectMapper) {
+    protected void configure(ObjectMapper mapper) {
+        this.objectMapper = mapper;
+
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    /**
+     * タイムゾーンを設定する
+     *
+     * @param timeZone タイムゾーン
+     */
+    public void setTimeZone(String timeZone) {
+        objectMapper.setTimeZone(TimeZone.getTimeZone(timeZone));
     }
 }

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
@@ -1,0 +1,28 @@
+package nablarch.integration.jaxrs.jersey;
+
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
+
+/**
+ * {@link JerseyJaxRsHandlerListFactory}向けの拡張実装として、Jackson2.xを使用してリクエスト/レスポンスの
+ * 変換を行う{@link Jackson2BodyConverter}実装クラス。
+ *
+ * Jackson2.xのモジュールを組み込み、{@link ObjectMapper}のサポートするデータ型の範囲を
+ * 拡張する
+ */
+public class JerseyJackson2BodyConverter extends Jackson2BodyConverter {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void configure(ObjectMapper objectMapper) {
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
@@ -15,26 +15,13 @@ import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
  * 拡張する
  */
 public class JerseyJackson2BodyConverter extends Jackson2BodyConverter {
-    private ObjectMapper objectMapper;
-
     /**
      * {@inheritDoc}
      */
     @Override
-    protected void configure(ObjectMapper mapper) {
-        this.objectMapper = mapper;
-
+    protected void configure(ObjectMapper objectMapper) {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    }
-
-    /**
-     * タイムゾーンを設定する
-     *
-     * @param timeZone タイムゾーン
-     */
-    public void setTimeZone(String timeZone) {
-        objectMapper.setTimeZone(TimeZone.getTimeZone(timeZone));
     }
 }

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverter.java
@@ -22,7 +22,7 @@ public class JerseyJackson2BodyConverter extends Jackson2BodyConverter {
     @Override
     protected void configure(ObjectMapper objectMapper) {
         objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
+        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));  // JacksonのデフォルトはUTC固定のため
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
@@ -7,7 +7,6 @@ import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxRsHandlerListFactory;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
 import nablarch.fw.web.HttpRequest;
-import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,15 +22,18 @@ public class JerseyJaxRsHandlerListFactory implements JaxRsHandlerListFactory {
     /** {@link Handler}のリスト */
     private final List<Handler<HttpRequest, ?>> handlerList;
 
+    private final JerseyJackson2BodyConverter jerseyJackson2BodyConverter;
+
     /**
      * コンストラクタ。
      */
     public JerseyJaxRsHandlerListFactory() {
 
-        final List<Handler<HttpRequest, ?>> list = new ArrayList<Handler<HttpRequest, ?>>();
+        final List<Handler<HttpRequest, ?>> list = new ArrayList<>();
 
         final BodyConvertHandler bodyConvertHandler = new BodyConvertHandler();
-        bodyConvertHandler.addBodyConverter(new JerseyJackson2BodyConverter());
+        jerseyJackson2BodyConverter = new JerseyJackson2BodyConverter();
+        bodyConvertHandler.addBodyConverter(jerseyJackson2BodyConverter);
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
         list.add(bodyConvertHandler);
@@ -44,5 +46,9 @@ public class JerseyJaxRsHandlerListFactory implements JaxRsHandlerListFactory {
     @Override
     public List<Handler<HttpRequest, ?>> createObject() {
         return handlerList;
+    }
+
+    public void setJacksonTimeZone(String jacksonTimeZone) {
+        jerseyJackson2BodyConverter.setTimeZone(jacksonTimeZone);
     }
 }

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
@@ -22,8 +22,6 @@ public class JerseyJaxRsHandlerListFactory implements JaxRsHandlerListFactory {
     /** {@link Handler}のリスト */
     private final List<Handler<HttpRequest, ?>> handlerList;
 
-    private final JerseyJackson2BodyConverter jerseyJackson2BodyConverter;
-
     /**
      * コンストラクタ。
      */
@@ -32,8 +30,7 @@ public class JerseyJaxRsHandlerListFactory implements JaxRsHandlerListFactory {
         final List<Handler<HttpRequest, ?>> list = new ArrayList<>();
 
         final BodyConvertHandler bodyConvertHandler = new BodyConvertHandler();
-        jerseyJackson2BodyConverter = new JerseyJackson2BodyConverter();
-        bodyConvertHandler.addBodyConverter(jerseyJackson2BodyConverter);
+        bodyConvertHandler.addBodyConverter(new JerseyJackson2BodyConverter());
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
         list.add(bodyConvertHandler);
@@ -46,9 +43,5 @@ public class JerseyJaxRsHandlerListFactory implements JaxRsHandlerListFactory {
     @Override
     public List<Handler<HttpRequest, ?>> createObject() {
         return handlerList;
-    }
-
-    public void setJacksonTimeZone(String jacksonTimeZone) {
-        jerseyJackson2BodyConverter.setTimeZone(jacksonTimeZone);
     }
 }

--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
@@ -31,7 +31,7 @@ public class JerseyJaxRsHandlerListFactory implements JaxRsHandlerListFactory {
         final List<Handler<HttpRequest, ?>> list = new ArrayList<Handler<HttpRequest, ?>>();
 
         final BodyConvertHandler bodyConvertHandler = new BodyConvertHandler();
-        bodyConvertHandler.addBodyConverter(new Jackson2BodyConverter());
+        bodyConvertHandler.addBodyConverter(new JerseyJackson2BodyConverter());
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
         list.add(bodyConvertHandler);

--- a/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverterTest.java
+++ b/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverterTest.java
@@ -62,36 +62,6 @@ public class JerseyJackson2BodyConverterTest {
     }
 
     @Test
-    public void dateAndTimeSerializeSetTimeZone() throws NoSuchMethodException {
-        JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
-        sut.setTimeZone("Asia/Tokyo");
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 11, 17, 11, 56, 29);
-        calendar.clear(Calendar.MILLISECOND);
-
-        DataClass data = new DataClass(
-                calendar.getTime(),
-                LocalDate.of(2024, 12, 17),
-                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
-                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
-        );
-
-        Method method = Resource.class.getMethod("get", DataClass.class);
-
-        HttpResponse response = sut.write(data, new ExecutionContext() {
-            @Override
-            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
-                return new JaxRsContext(method);
-            }
-        });
-
-        String json = response.getBodyString();
-
-        assertThat(json, is("{\"utilDate\":\"2024-12-17T11:56:29.000+09:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}"));
-    }
-
-    @Test
     public void dateAndTimeDeserialize() throws NoSuchMethodException {
         JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
 
@@ -126,47 +96,6 @@ public class JerseyJackson2BodyConverterTest {
                 LocalDate.of(2024, 12, 17),
                 LocalDateTime.of(2024, 12, 17, 11, 56, 29),
                 OffsetDateTime.of(2024, 12, 17, 2, 56, 29, 0, ZoneOffset.UTC)
-        );
-
-        assertThat(data, is(expected));
-    }
-
-    @Test
-    public void dateAndTimeDeserializeSetTimeZone() throws NoSuchMethodException {
-        JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
-        sut.setTimeZone("Asia/Tokyo");
-
-        String json = "{\"utilDate\":\"2024-12-17T02:56:29.000+00:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}";
-
-        HttpRequest request = new JaxRsHttpRequest(null);
-
-        Method method = Resource.class.getMethod("get", DataClass.class);
-
-        MockServletRequest servletRequest = new MockServletRequest() {
-            @Override
-            public BufferedReader getReader() throws IOException {
-                return new BufferedReader(new StringReader(json));
-            }
-        };
-        MockServletResponse servletResponse = new MockServletResponse();
-        MockServletContext servletContext = new MockServletContext();
-
-        DataClass data = (DataClass) sut.read(request, new ServletExecutionContext(servletRequest, servletResponse, servletContext) {
-            @Override
-            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
-                return new JaxRsContext(method);
-            }
-        });
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 11, 17, 11, 56, 29);
-        calendar.clear(Calendar.MILLISECOND);
-
-        DataClass expected = new DataClass(
-                calendar.getTime(),
-                LocalDate.of(2024, 12, 17),
-                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
-                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
         );
 
         assertThat(data, is(expected));

--- a/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverterTest.java
+++ b/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverterTest.java
@@ -1,0 +1,115 @@
+package nablarch.integration.jaxrs.jersey;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.jaxrs.JaxRsContext;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import nablarch.fw.web.HttpCookie;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.Test;
+
+/**
+ * {@link JerseyJackson2BodyConverter}のテストクラス
+ */
+public class JerseyJackson2BodyConverterTest {
+    @Test
+    public void dateAndTimeSerialize() throws NoSuchMethodException {
+        JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
+
+        ZoneOffset offset = ZonedDateTime.now(ZoneId.systemDefault()).getOffset();
+
+        DataClass data = new DataClass(
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, offset)
+        );
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        HttpResponse response = sut.write(data, new ExecutionContext() {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        String json = response.getBodyString();
+
+        assertThat(json, is("{\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29" + offset + "\"}"));
+    }
+
+    @Test
+    public void dateAndTimeDeserialize() throws NoSuchMethodException {
+        JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
+
+        ZoneOffset offset = ZonedDateTime.now(ZoneId.systemDefault()).getOffset();
+
+        String json = "{\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29" + offset + "\"}";
+
+        HttpRequest request = new JaxRsHttpRequest(null);
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        MockServletRequest servletRequest = new MockServletRequest() {
+            @Override
+            public BufferedReader getReader() throws IOException {
+                return new BufferedReader(new StringReader(json));
+            }
+        };
+        MockServletResponse servletResponse = new MockServletResponse();
+        MockServletContext servletContext = new MockServletContext();
+
+        DataClass data = (DataClass) sut.read(request, new ServletExecutionContext(servletRequest, servletResponse, servletContext) {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        DataClass expected = new DataClass(
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, offset)
+        );
+
+
+        assertThat(data, is(expected));
+    }
+
+    public record DataClass(
+            LocalDate date,
+            LocalDateTime localDateTime,
+            OffsetDateTime offsetDateTime
+    ) {
+    }
+
+    public static class Resource {
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public DataClass get(DataClass data) {
+            return null;
+        }
+    }
+}

--- a/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverterTest.java
+++ b/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJackson2BodyConverterTest.java
@@ -10,12 +10,9 @@ import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Map;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
@@ -65,6 +62,36 @@ public class JerseyJackson2BodyConverterTest {
     }
 
     @Test
+    public void dateAndTimeSerializeSetTimeZone() throws NoSuchMethodException {
+        JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
+        sut.setTimeZone("Asia/Tokyo");
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 11, 17, 11, 56, 29);
+        calendar.clear(Calendar.MILLISECOND);
+
+        DataClass data = new DataClass(
+                calendar.getTime(),
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
+        );
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        HttpResponse response = sut.write(data, new ExecutionContext() {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        String json = response.getBodyString();
+
+        assertThat(json, is("{\"utilDate\":\"2024-12-17T11:56:29.000+09:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}"));
+    }
+
+    @Test
     public void dateAndTimeDeserialize() throws NoSuchMethodException {
         JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
 
@@ -99,6 +126,47 @@ public class JerseyJackson2BodyConverterTest {
                 LocalDate.of(2024, 12, 17),
                 LocalDateTime.of(2024, 12, 17, 11, 56, 29),
                 OffsetDateTime.of(2024, 12, 17, 2, 56, 29, 0, ZoneOffset.UTC)
+        );
+
+        assertThat(data, is(expected));
+    }
+
+    @Test
+    public void dateAndTimeDeserializeSetTimeZone() throws NoSuchMethodException {
+        JerseyJackson2BodyConverter sut = new JerseyJackson2BodyConverter();
+        sut.setTimeZone("Asia/Tokyo");
+
+        String json = "{\"utilDate\":\"2024-12-17T02:56:29.000+00:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}";
+
+        HttpRequest request = new JaxRsHttpRequest(null);
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        MockServletRequest servletRequest = new MockServletRequest() {
+            @Override
+            public BufferedReader getReader() throws IOException {
+                return new BufferedReader(new StringReader(json));
+            }
+        };
+        MockServletResponse servletResponse = new MockServletResponse();
+        MockServletContext servletContext = new MockServletContext();
+
+        DataClass data = (DataClass) sut.read(request, new ServletExecutionContext(servletRequest, servletResponse, servletContext) {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 11, 17, 11, 56, 29);
+        calendar.clear(Calendar.MILLISECOND);
+
+        DataClass expected = new DataClass(
+                calendar.getTime(),
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
         );
 
         assertThat(data, is(expected));

--- a/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
@@ -44,26 +44,4 @@ public class JerseyJaxRsHandlerListFactoryTest {
 
         assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
     }
-
-    @Test
-    public void testCreateInitialize() throws Exception {
-        sut = new JerseyJaxRsHandlerListFactory();
-        sut.setJacksonTimeZone("Asia/Tokyo");
-
-        List<Handler<HttpRequest, ?>> list = sut.createObject();
-
-        assertThat(list.size(), is(2));
-
-        assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
-        List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
-        assertThat(bodyConverters.size(), is(3));
-        assertThat(bodyConverters.get(0), instanceOf(JerseyJackson2BodyConverter.class));
-        assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
-        assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
-
-        ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
-        assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("Asia/Tokyo")));
-
-        assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
-    }
 }

--- a/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
@@ -1,5 +1,6 @@
 package nablarch.integration.jaxrs.jersey;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import nablarch.fw.Handler;
 import nablarch.fw.jaxrs.BodyConvertHandler;
 import nablarch.fw.jaxrs.BodyConverter;
@@ -7,15 +8,15 @@ import nablarch.fw.jaxrs.FormUrlEncodedConverter;
 import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
 import nablarch.fw.web.HttpRequest;
-import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
 import nablarch.test.support.reflection.ReflectionUtil;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.TimeZone;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * {@link JerseyJaxRsHandlerListFactory}のテストクラス。
@@ -37,6 +38,31 @@ public class JerseyJaxRsHandlerListFactoryTest {
         assertThat(bodyConverters.get(0), instanceOf(JerseyJackson2BodyConverter.class));
         assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
         assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
+
+        ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
+        assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("UTC")));
+
+        assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
+    }
+
+    @Test
+    public void testCreateInitialize() throws Exception {
+        sut = new JerseyJaxRsHandlerListFactory();
+        sut.setJacksonTimeZone("Asia/Tokyo");
+
+        List<Handler<HttpRequest, ?>> list = sut.createObject();
+
+        assertThat(list.size(), is(2));
+
+        assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
+        List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
+        assertThat(bodyConverters.size(), is(3));
+        assertThat(bodyConverters.get(0), instanceOf(JerseyJackson2BodyConverter.class));
+        assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
+        assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
+
+        ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
+        assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("Asia/Tokyo")));
 
         assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
     }

--- a/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
@@ -34,7 +34,7 @@ public class JerseyJaxRsHandlerListFactoryTest {
         assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
         List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
         assertThat(bodyConverters.size(), is(3));
-        assertThat(bodyConverters.get(0), instanceOf(Jackson2BodyConverter.class));
+        assertThat(bodyConverters.get(0), instanceOf(JerseyJackson2BodyConverter.class));
         assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
         assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
 

--- a/nablarch-resteasy-adaptor/pom.xml
+++ b/nablarch-resteasy-adaptor/pom.xml
@@ -16,10 +16,8 @@
       <artifactId>nablarch-jackson-adaptor</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.17.1</version>
-      <scope>test</scope>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
 
     <dependency>
@@ -34,15 +32,9 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.nablarch.dev</groupId>
       <artifactId>nablarch-test-support</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 </project>

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
@@ -22,7 +22,7 @@ public class ResteasyJackson2BodyConverter extends Jackson2BodyConverter {
     @Override
     protected void configure(ObjectMapper objectMapper) {
         objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));  // JacksonのデフォルトはUTC固定のため
+        objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
@@ -15,26 +15,13 @@ import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
  * 拡張する
  */
 public class ResteasyJackson2BodyConverter extends Jackson2BodyConverter {
-    private ObjectMapper objectMapper;
-
     /**
      * {@inheritDoc}
      */
     @Override
-    protected void configure(ObjectMapper mapper) {
-        this.objectMapper = mapper;
-
+    protected void configure(ObjectMapper objectMapper) {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    }
-
-    /**
-     * タイムゾーンを設定する
-     *
-     * @param timeZone タイムゾーン
-     */
-    public void setTimeZone(String timeZone) {
-        objectMapper.setTimeZone(TimeZone.getTimeZone(timeZone));
     }
 }

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
@@ -1,0 +1,28 @@
+package nablarch.integration.jaxrs.resteasy;
+
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
+
+/**
+ * {@link ResteasyJaxRsHandlerListFactory}向けの拡張実装として、Jackson2.xを使用してリクエスト/レスポンスの
+ * 変換を行う{@link Jackson2BodyConverter}実装クラス。
+ *
+ * Jackson2.xのモジュールを組み込み、{@link ObjectMapper}のサポートするデータ型の範囲を
+ * 拡張する
+ */
+public class ResteasyJackson2BodyConverter extends Jackson2BodyConverter {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void configure(ObjectMapper objectMapper) {
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
@@ -22,7 +22,7 @@ public class ResteasyJackson2BodyConverter extends Jackson2BodyConverter {
     @Override
     protected void configure(ObjectMapper objectMapper) {
         objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
+        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));  // JacksonのデフォルトはUTC固定のため
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
@@ -1,6 +1,5 @@
 package nablarch.integration.jaxrs.resteasy;
 
-import java.time.ZoneId;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverter.java
@@ -10,18 +10,31 @@ import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
 /**
  * {@link ResteasyJaxRsHandlerListFactory}向けの拡張実装として、Jackson2.xを使用してリクエスト/レスポンスの
  * 変換を行う{@link Jackson2BodyConverter}実装クラス。
- *
+ * <p>
  * Jackson2.xのモジュールを組み込み、{@link ObjectMapper}のサポートするデータ型の範囲を
  * 拡張する
  */
 public class ResteasyJackson2BodyConverter extends Jackson2BodyConverter {
+    private ObjectMapper objectMapper;
+
     /**
      * {@inheritDoc}
      */
     @Override
-    protected void configure(ObjectMapper objectMapper) {
+    protected void configure(ObjectMapper mapper) {
+        this.objectMapper = mapper;
+
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.setTimeZone(TimeZone.getTimeZone("UTC"));
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    /**
+     * タイムゾーンを設定する
+     *
+     * @param timeZone タイムゾーン
+     */
+    public void setTimeZone(String timeZone) {
+        objectMapper.setTimeZone(TimeZone.getTimeZone(timeZone));
     }
 }

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
@@ -7,7 +7,6 @@ import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxRsHandlerListFactory;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
 import nablarch.fw.web.HttpRequest;
-import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,15 +22,20 @@ public class ResteasyJaxRsHandlerListFactory implements JaxRsHandlerListFactory 
     /** {@link Handler}のリスト */
     private final List<Handler<HttpRequest, ?>> handlerList;
 
+    private final ResteasyJackson2BodyConverter resteasyJackson2BodyConverter;
+
+    private String jacksonTimeZone;
+
     /**
      * コンストラクタ。
      */
     public ResteasyJaxRsHandlerListFactory() {
 
-        final List<Handler<HttpRequest, ?>> list = new ArrayList<Handler<HttpRequest, ?>>();
+        final List<Handler<HttpRequest, ?>> list = new ArrayList<>();
 
         final BodyConvertHandler bodyConvertHandler = new BodyConvertHandler();
-        bodyConvertHandler.addBodyConverter(new ResteasyJackson2BodyConverter());
+        resteasyJackson2BodyConverter = new ResteasyJackson2BodyConverter();
+        bodyConvertHandler.addBodyConverter(resteasyJackson2BodyConverter);
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
         list.add(bodyConvertHandler);
@@ -44,5 +48,9 @@ public class ResteasyJaxRsHandlerListFactory implements JaxRsHandlerListFactory 
     @Override
     public List<Handler<HttpRequest, ?>> createObject() {
         return handlerList;
+    }
+
+    public void setJacksonTimeZone(String jacksonTimeZone) {
+        resteasyJackson2BodyConverter.setTimeZone(jacksonTimeZone);
     }
 }

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
@@ -22,10 +22,6 @@ public class ResteasyJaxRsHandlerListFactory implements JaxRsHandlerListFactory 
     /** {@link Handler}のリスト */
     private final List<Handler<HttpRequest, ?>> handlerList;
 
-    private final ResteasyJackson2BodyConverter resteasyJackson2BodyConverter;
-
-    private String jacksonTimeZone;
-
     /**
      * コンストラクタ。
      */
@@ -34,8 +30,7 @@ public class ResteasyJaxRsHandlerListFactory implements JaxRsHandlerListFactory 
         final List<Handler<HttpRequest, ?>> list = new ArrayList<>();
 
         final BodyConvertHandler bodyConvertHandler = new BodyConvertHandler();
-        resteasyJackson2BodyConverter = new ResteasyJackson2BodyConverter();
-        bodyConvertHandler.addBodyConverter(resteasyJackson2BodyConverter);
+        bodyConvertHandler.addBodyConverter(new ResteasyJackson2BodyConverter());
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
         list.add(bodyConvertHandler);
@@ -48,9 +43,5 @@ public class ResteasyJaxRsHandlerListFactory implements JaxRsHandlerListFactory 
     @Override
     public List<Handler<HttpRequest, ?>> createObject() {
         return handlerList;
-    }
-
-    public void setJacksonTimeZone(String jacksonTimeZone) {
-        resteasyJackson2BodyConverter.setTimeZone(jacksonTimeZone);
     }
 }

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
@@ -31,7 +31,7 @@ public class ResteasyJaxRsHandlerListFactory implements JaxRsHandlerListFactory 
         final List<Handler<HttpRequest, ?>> list = new ArrayList<Handler<HttpRequest, ?>>();
 
         final BodyConvertHandler bodyConvertHandler = new BodyConvertHandler();
-        bodyConvertHandler.addBodyConverter(new Jackson2BodyConverter());
+        bodyConvertHandler.addBodyConverter(new ResteasyJackson2BodyConverter());
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
         list.add(bodyConvertHandler);

--- a/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverterTest.java
+++ b/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverterTest.java
@@ -62,36 +62,6 @@ public class ResteasyJackson2BodyConverterTest {
     }
 
     @Test
-    public void dateAndTimeSerializeSetTimeZone() throws NoSuchMethodException {
-        ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
-        sut.setTimeZone("Asia/Tokyo");
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 11, 17, 11, 56, 29);
-        calendar.clear(Calendar.MILLISECOND);
-
-        DataClass data = new DataClass(
-                calendar.getTime(),
-                LocalDate.of(2024, 12, 17),
-                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
-                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
-        );
-
-        Method method = Resource.class.getMethod("get", DataClass.class);
-
-        HttpResponse response = sut.write(data, new ExecutionContext() {
-            @Override
-            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
-                return new JaxRsContext(method);
-            }
-        });
-
-        String json = response.getBodyString();
-
-        assertThat(json, is("{\"utilDate\":\"2024-12-17T11:56:29.000+09:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}"));
-    }
-
-    @Test
     public void dateAndTimeDeserialize() throws NoSuchMethodException {
         ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
 
@@ -126,47 +96,6 @@ public class ResteasyJackson2BodyConverterTest {
                 LocalDate.of(2024, 12, 17),
                 LocalDateTime.of(2024, 12, 17, 11, 56, 29),
                 OffsetDateTime.of(2024, 12, 17, 2, 56, 29, 0, ZoneOffset.UTC)
-        );
-
-        assertThat(data, is(expected));
-    }
-
-    @Test
-    public void dateAndTimeDeserializeSetTimeZone() throws NoSuchMethodException {
-        ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
-        sut.setTimeZone("Asia/Tokyo");
-
-        String json = "{\"utilDate\":\"2024-12-17T02:56:29.000+00:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}";
-
-        HttpRequest request = new JaxRsHttpRequest(null);
-
-        Method method = Resource.class.getMethod("get", DataClass.class);
-
-        MockServletRequest servletRequest = new MockServletRequest() {
-            @Override
-            public BufferedReader getReader() throws IOException {
-                return new BufferedReader(new StringReader(json));
-            }
-        };
-        MockServletResponse servletResponse = new MockServletResponse();
-        MockServletContext servletContext = new MockServletContext();
-
-        DataClass data = (DataClass) sut.read(request, new ServletExecutionContext(servletRequest, servletResponse, servletContext) {
-            @Override
-            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
-                return new JaxRsContext(method);
-            }
-        });
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 11, 17, 11, 56, 29);
-        calendar.clear(Calendar.MILLISECOND);
-
-        DataClass expected = new DataClass(
-                calendar.getTime(),
-                LocalDate.of(2024, 12, 17),
-                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
-                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
         );
 
         assertThat(data, is(expected));

--- a/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverterTest.java
+++ b/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverterTest.java
@@ -1,0 +1,113 @@
+package nablarch.integration.jaxrs.resteasy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.jaxrs.JaxRsContext;
+import nablarch.fw.jaxrs.JaxRsHttpRequest;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import nablarch.test.support.web.servlet.MockServletContext;
+import nablarch.test.support.web.servlet.MockServletRequest;
+import nablarch.test.support.web.servlet.MockServletResponse;
+import org.junit.Test;
+
+/**
+ * {@link ResteasyJackson2BodyConverter}のテストクラス
+ */
+public class ResteasyJackson2BodyConverterTest {
+    @Test
+    public void dateAndTimeSerialize() throws NoSuchMethodException {
+        ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
+
+        ZoneOffset offset = ZonedDateTime.now(ZoneId.systemDefault()).getOffset();
+
+        DataClass data = new DataClass(
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, offset)
+        );
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        HttpResponse response = sut.write(data, new ExecutionContext() {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        String json = response.getBodyString();
+
+        assertThat(json, is("{\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29" + offset + "\"}"));
+    }
+
+    @Test
+    public void dateAndTimeDeserialize() throws NoSuchMethodException {
+        ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
+
+        ZoneOffset offset = ZonedDateTime.now(ZoneId.systemDefault()).getOffset();
+
+        String json = "{\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29" + offset + "\"}";
+
+        HttpRequest request = new JaxRsHttpRequest(null);
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        MockServletRequest servletRequest = new MockServletRequest() {
+            @Override
+            public BufferedReader getReader() throws IOException {
+                return new BufferedReader(new StringReader(json));
+            }
+        };
+        MockServletResponse servletResponse = new MockServletResponse();
+        MockServletContext servletContext = new MockServletContext();
+
+        DataClass data = (DataClass) sut.read(request, new ServletExecutionContext(servletRequest, servletResponse, servletContext) {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        DataClass expected = new DataClass(
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, offset)
+        );
+
+
+        assertThat(data, is(expected));
+    }
+
+    public record DataClass(
+            LocalDate date,
+            LocalDateTime localDateTime,
+            OffsetDateTime offsetDateTime
+    ) {
+    }
+
+    public static class Resource {
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public DataClass get(DataClass data) {
+            return null;
+        }
+    }
+}

--- a/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverterTest.java
+++ b/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJackson2BodyConverterTest.java
@@ -62,10 +62,40 @@ public class ResteasyJackson2BodyConverterTest {
     }
 
     @Test
+    public void dateAndTimeSerializeSetTimeZone() throws NoSuchMethodException {
+        ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
+        sut.setTimeZone("Asia/Tokyo");
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 11, 17, 11, 56, 29);
+        calendar.clear(Calendar.MILLISECOND);
+
+        DataClass data = new DataClass(
+                calendar.getTime(),
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
+        );
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        HttpResponse response = sut.write(data, new ExecutionContext() {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        String json = response.getBodyString();
+
+        assertThat(json, is("{\"utilDate\":\"2024-12-17T11:56:29.000+09:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}"));
+    }
+
+    @Test
     public void dateAndTimeDeserialize() throws NoSuchMethodException {
         ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
 
-        String json = "{\"utilDate\":\"2024-12-17T02:56:29.000+00:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+0900\"}";
+        String json = "{\"utilDate\":\"2024-12-17T02:56:29.000+00:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}";
 
         HttpRequest request = new JaxRsHttpRequest(null);
 
@@ -98,6 +128,46 @@ public class ResteasyJackson2BodyConverterTest {
                 OffsetDateTime.of(2024, 12, 17, 2, 56, 29, 0, ZoneOffset.UTC)
         );
 
+        assertThat(data, is(expected));
+    }
+
+    @Test
+    public void dateAndTimeDeserializeSetTimeZone() throws NoSuchMethodException {
+        ResteasyJackson2BodyConverter sut = new ResteasyJackson2BodyConverter();
+        sut.setTimeZone("Asia/Tokyo");
+
+        String json = "{\"utilDate\":\"2024-12-17T02:56:29.000+00:00\",\"date\":\"2024-12-17\",\"localDateTime\":\"2024-12-17T11:56:29\",\"offsetDateTime\":\"2024-12-17T11:56:29+09:00\"}";
+
+        HttpRequest request = new JaxRsHttpRequest(null);
+
+        Method method = Resource.class.getMethod("get", DataClass.class);
+
+        MockServletRequest servletRequest = new MockServletRequest() {
+            @Override
+            public BufferedReader getReader() throws IOException {
+                return new BufferedReader(new StringReader(json));
+            }
+        };
+        MockServletResponse servletResponse = new MockServletResponse();
+        MockServletContext servletContext = new MockServletContext();
+
+        DataClass data = (DataClass) sut.read(request, new ServletExecutionContext(servletRequest, servletResponse, servletContext) {
+            @Override
+            public JaxRsContext getRequestScopedVar(String varName) throws ClassCastException {
+                return new JaxRsContext(method);
+            }
+        });
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 11, 17, 11, 56, 29);
+        calendar.clear(Calendar.MILLISECOND);
+
+        DataClass expected = new DataClass(
+                calendar.getTime(),
+                LocalDate.of(2024, 12, 17),
+                LocalDateTime.of(2024, 12, 17, 11, 56, 29),
+                OffsetDateTime.of(2024, 12, 17, 11, 56, 29, 0, ZoneOffset.ofHours(9))
+        );
 
         assertThat(data, is(expected));
     }

--- a/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
@@ -16,7 +16,6 @@ import java.util.TimeZone;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 /**
@@ -42,28 +41,6 @@ public class ResteasyJaxRsHandlerListFactoryTest {
 
         ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
         assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("UTC")));
-
-        assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
-    }
-
-    @Test
-    public void testCreateInitialize() throws Exception {
-        sut = new ResteasyJaxRsHandlerListFactory();
-        sut.setJacksonTimeZone("Asia/Tokyo");
-
-        List<Handler<HttpRequest, ?>> list = sut.createObject();
-
-        assertThat(list.size(), is(2));
-
-        assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
-        List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
-        assertThat(bodyConverters.size(), is(3));
-        assertThat(bodyConverters.get(0), instanceOf(ResteasyJackson2BodyConverter.class));
-        assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
-        assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
-
-        ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
-        assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("Asia/Tokyo")));
 
         assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
     }

--- a/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
@@ -1,5 +1,6 @@
 package nablarch.integration.jaxrs.resteasy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import nablarch.fw.Handler;
 import nablarch.fw.jaxrs.BodyConvertHandler;
 import nablarch.fw.jaxrs.BodyConverter;
@@ -7,15 +8,16 @@ import nablarch.fw.jaxrs.FormUrlEncodedConverter;
 import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
 import nablarch.fw.web.HttpRequest;
-import nablarch.integration.jaxrs.jackson.Jackson2BodyConverter;
 import nablarch.test.support.reflection.ReflectionUtil;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.TimeZone;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * {@link ResteasyJaxRsHandlerListFactory}のテストクラス。
@@ -37,6 +39,31 @@ public class ResteasyJaxRsHandlerListFactoryTest {
         assertThat(bodyConverters.get(0), instanceOf(ResteasyJackson2BodyConverter.class));
         assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
         assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
+
+        ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
+        assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("UTC")));
+
+        assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
+    }
+
+    @Test
+    public void testCreateInitialize() throws Exception {
+        sut = new ResteasyJaxRsHandlerListFactory();
+        sut.setJacksonTimeZone("Asia/Tokyo");
+
+        List<Handler<HttpRequest, ?>> list = sut.createObject();
+
+        assertThat(list.size(), is(2));
+
+        assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
+        List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
+        assertThat(bodyConverters.size(), is(3));
+        assertThat(bodyConverters.get(0), instanceOf(ResteasyJackson2BodyConverter.class));
+        assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
+        assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
+
+        ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
+        assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("Asia/Tokyo")));
 
         assertThat(list.get(1), instanceOf(JaxRsBeanValidationHandler.class));
     }

--- a/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
@@ -34,7 +34,7 @@ public class ResteasyJaxRsHandlerListFactoryTest {
         assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
         List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
         assertThat(bodyConverters.size(), is(3));
-        assertThat(bodyConverters.get(0), instanceOf(Jackson2BodyConverter.class));
+        assertThat(bodyConverters.get(0), instanceOf(ResteasyJackson2BodyConverter.class));
         assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
         assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,29 @@
     <relativePath/>
   </parent>
 
+  <properties>
+    <jackson.version>2.17.1</jackson.version>
+  </properties>
+
   <modules>
     <module>nablarch-jackson-adaptor</module>
     <module>nablarch-jersey-adaptor</module>
     <module>nablarch-resteasy-adaptor</module>
   </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
 </project>


### PR DESCRIPTION
# 変更内容

Date and Time APIのサポートの追加を追加。

主な変更内容。

- Jersey、RESTEasyアダプタにJacksonのDate and Time APIのモジュールを追加し、デシリアライズ時のフォーマット調整を設定
  - nablarch-jackson-adaptorの方は拡張実装しないとカスタマイズできないため、利用者側で似たような拡張が入っているであろうことを考えると変更はよくないと判断
  - Jersey、RESTEasyアダプタは公開APIでなく、かつ拡張もできないため扱えるデータ型が広がる分には問題ないと考える

付随的な変更内容。

- Jacksonのバージョンは親モジュール側にまとめ、`dependencyManagement`として定義
- 依存関係にServlet APIが含まれていたが、`jakarta.jakartaee-api`が入っているので重複しているので不要と考え削除

# ドキュメントへの反映

Jersey、RESTEasyのアダプタ向けに

> JSONのコンバータには Jackson2BodyConverter が設定される。

と書かれている部分を

> JSONのコンバータには jackson-datatype-jsr310 を組み込むように拡張した Jackson2BodyConverter が設定される。

という感じに変更するのかなと思います。

https://nablarch.github.io/docs/6u2/doc/application_framework/adaptors/jaxrs_adaptor.html