### PR TITLE
マルチパートのサポートを追加

### DIFF
--- a/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
+++ b/nablarch-jersey-adaptor/src/main/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactory.java
@@ -6,6 +6,7 @@ import nablarch.fw.jaxrs.FormUrlEncodedConverter;
 import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxRsHandlerListFactory;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
+import nablarch.fw.jaxrs.MultipartFormDataBodyConverter;
 import nablarch.fw.web.HttpRequest;
 
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ public class JerseyJaxRsHandlerListFactory implements JaxRsHandlerListFactory {
         bodyConvertHandler.addBodyConverter(new JerseyJackson2BodyConverter());
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
+        bodyConvertHandler.addBodyConverter(new MultipartFormDataBodyConverter());
         list.add(bodyConvertHandler);
 
         list.add(new JaxRsBeanValidationHandler());

--- a/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-jersey-adaptor/src/test/java/nablarch/integration/jaxrs/jersey/JerseyJaxRsHandlerListFactoryTest.java
@@ -7,6 +7,7 @@ import nablarch.fw.jaxrs.BodyConverter;
 import nablarch.fw.jaxrs.FormUrlEncodedConverter;
 import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
+import nablarch.fw.jaxrs.MultipartFormDataBodyConverter;
 import nablarch.fw.web.HttpRequest;
 import nablarch.test.support.reflection.ReflectionUtil;
 import org.junit.Test;
@@ -34,10 +35,11 @@ public class JerseyJaxRsHandlerListFactoryTest {
 
         assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
         List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
-        assertThat(bodyConverters.size(), is(3));
+        assertThat(bodyConverters.size(), is(4));
         assertThat(bodyConverters.get(0), instanceOf(JerseyJackson2BodyConverter.class));
         assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
         assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
+        assertThat(bodyConverters.get(3), instanceOf(MultipartFormDataBodyConverter.class));
 
         ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
         assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("UTC")));

--- a/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
+++ b/nablarch-resteasy-adaptor/src/main/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactory.java
@@ -6,6 +6,7 @@ import nablarch.fw.jaxrs.FormUrlEncodedConverter;
 import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxRsHandlerListFactory;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
+import nablarch.fw.jaxrs.MultipartFormDataBodyConverter;
 import nablarch.fw.web.HttpRequest;
 
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ public class ResteasyJaxRsHandlerListFactory implements JaxRsHandlerListFactory 
         bodyConvertHandler.addBodyConverter(new ResteasyJackson2BodyConverter());
         bodyConvertHandler.addBodyConverter(new JaxbBodyConverter());
         bodyConvertHandler.addBodyConverter(new FormUrlEncodedConverter());
+        bodyConvertHandler.addBodyConverter(new MultipartFormDataBodyConverter());
         list.add(bodyConvertHandler);
 
         list.add(new JaxRsBeanValidationHandler());

--- a/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
+++ b/nablarch-resteasy-adaptor/src/test/java/nablarch/integration/jaxrs/resteasy/ResteasyJaxRsHandlerListFactoryTest.java
@@ -7,6 +7,7 @@ import nablarch.fw.jaxrs.BodyConverter;
 import nablarch.fw.jaxrs.FormUrlEncodedConverter;
 import nablarch.fw.jaxrs.JaxRsBeanValidationHandler;
 import nablarch.fw.jaxrs.JaxbBodyConverter;
+import nablarch.fw.jaxrs.MultipartFormDataBodyConverter;
 import nablarch.fw.web.HttpRequest;
 import nablarch.test.support.reflection.ReflectionUtil;
 import org.junit.Test;
@@ -34,10 +35,11 @@ public class ResteasyJaxRsHandlerListFactoryTest {
 
         assertThat(list.get(0), instanceOf(BodyConvertHandler.class));
         List<BodyConverter> bodyConverters = ReflectionUtil.getFieldValue(list.get(0), "bodyConverters");
-        assertThat(bodyConverters.size(), is(3));
+        assertThat(bodyConverters.size(), is(4));
         assertThat(bodyConverters.get(0), instanceOf(ResteasyJackson2BodyConverter.class));
         assertThat(bodyConverters.get(1), instanceOf(JaxbBodyConverter.class));
         assertThat(bodyConverters.get(2), instanceOf(FormUrlEncodedConverter.class));
+        assertThat(bodyConverters.get(3), instanceOf(MultipartFormDataBodyConverter.class));
 
         ObjectMapper objectMapper = ReflectionUtil.getFieldValue(bodyConverters.get(0), "objectMapper");
         assertThat(objectMapper.getDeserializationConfig().getTimeZone(), is(TimeZone.getTimeZone("UTC")));


### PR DESCRIPTION
# 概要

https://github.com/nablarch/nablarch-fw-jaxrs/pull/45 の対の内容。

nablarch-fw-jaxrsで作成した`MultipartFormDataBodyConverter`を`JerseyJaxRsHandlerListFactory`および`ResteasyJaxRsHandlerListFactory`に設定。

# 確認内容

- nablarch-example-restに組み込み、`multipart/form-data`のリクエストが処理できることを確認

設定した内容。

```xml
  <!-- ファイルアップロード機能設定 -->
  <import file="nablarch/webui/multipart.xml" />
```

と`multipartHandler`をハンドラキューに追加。